### PR TITLE
Read pressure data from the BME280 sensor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var Service, Characteristic, Accessory;
+var Service, Characteristic, CustomCharacteristic, Accessory;
 
 const DataCache = require('./lib/data_cache');
 const http = require('http');
@@ -7,6 +7,7 @@ const http = require('http');
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
+  CustomCharacteristic = require('./lib/custom_characteristics')(Characteristic);
   Accessory = homebridge.hap.Accessory;
   homebridge.registerAccessory(
     "homebridge-airrohr",
@@ -87,6 +88,7 @@ function AirRohrAccessory(log, config) {
 
     // Temperature Sensor
     this.temperatureService = new Service.TemperatureSensor(`Temperature ${this.name}`);
+    this.temperatureService.addOptionalCharacteristic(CustomCharacteristic.AirPressure);
 
     // Humidity sensor
     this.humidityService = new Service.HumiditySensor(`Humidity ${this.name}`);
@@ -118,6 +120,15 @@ function AirRohrAccessory(log, config) {
         this.humidityService.setCharacteristic(
           Characteristic.CurrentRelativeHumidity,
           this.humidity
+        );
+      }
+      let pressure = dataCache.pressure;
+      if (pressure) {
+        this.log("Measured pressure", pressure, "hPa");
+        this.pressure = pressure;
+        this.temperatureService.setCharacteristic(
+          CustomCharacteristic.AirPressure,
+          this.pressure
         );
       }
       let pm25 = dataCache.pm25;

--- a/lib/custom_characteristics.js
+++ b/lib/custom_characteristics.js
@@ -1,0 +1,21 @@
+var inherits = require('util').inherits;
+
+function CustomCharacteristics(Characteristic) {
+  this.AirPressure = function() {
+    Characteristic.call(this, 'Air Pressure', 'E863F10F-079E-48FF-8F27-9C2605A29F52');
+    this.setProps({
+      format: Characteristic.Formats.FLOAT,
+      unit: 'hectopascals',
+      minValue: 700,
+      maxValue: 1100,
+      minStep: 1,
+      perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+    });
+    this.value = this.getDefaultValue();
+  };
+  inherits(this.AirPressure, Characteristic);
+
+  return this;
+}
+
+module.exports = CustomCharacteristics;

--- a/lib/custom_characteristics.js
+++ b/lib/custom_characteristics.js
@@ -1,4 +1,4 @@
-var inherits = require('util').inherits;
+const inherits = require('util').inherits;
 
 function CustomCharacteristics(Characteristic) {
   this.AirPressure = function() {

--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -5,6 +5,7 @@ class DataCache {
     this.software_version = null;
     this.temperature = null;
     this.humidity = null;
+    this.pressure = null;
     this.pm25 = null;
     this.pm10 = null;
   }
@@ -24,6 +25,7 @@ class DataCache {
         this._updateAirQuality(airquality_json);
         this._updateHumidity(temp_json);
         this._updateTemperature(temp_json);
+        this._updatePressure(temp_json);
         callback(null);
       });
     });
@@ -38,6 +40,7 @@ class DataCache {
       this._updateAirQuality(json);
       this._updateHumidity(json);
       this._updateTemperature(json);
+      this._updatePressure(json);
       callback(null);
     })
   }
@@ -59,6 +62,17 @@ class DataCache {
       const value = this._findValue(json, key);
       if (value) {
         this.temperature = parseFloat(value);
+        break;
+      }
+    }
+  }
+
+  _updatePressure(json) {
+    const pressureKeys = ['pressure', 'BME280_pressure'];
+    for (let key of pressureKeys) {
+      const value = this._findValue(json, key);
+      if (value) {
+        this.pressure = parseFloat(value) / 100;
         break;
       }
     }

--- a/sample_data/api_data_temp_bme280.json
+++ b/sample_data/api_data_temp_bme280.json
@@ -1,0 +1,44 @@
+[
+    {
+        "sensordatavalues": [
+            {
+                "value_type": "temperature",
+                "value": "10.87",
+                "id": 1898962042
+            },
+            {
+                "value_type": "humidity",
+                "value": "54.34",
+                "id": 1898962043
+            },
+            {
+                "value": "99040.13",
+                "value_type": "pressure",
+                "id": 1898962044
+            },
+            {
+                "value_type": "pressure_at_sealevel",
+                "value": 99493.59
+            }
+        ],
+        "sampling_rate": null,
+        "sensor": {
+            "pin": "11",
+            "sensor_type": {
+                "name": "BME280",
+                "manufacturer": "Bosch",
+                "id": 17
+            },
+            "id": 4094
+        },
+        "timestamp": "2018-03-05 17:33:37",
+        "location": {
+            "country": "DE",
+            "latitude": "52.411",
+            "longitude": "9.012",
+            "altitude": "38.0",
+            "id": 2061
+        },
+        "id": 878260739
+    }
+]

--- a/test/test_data_cache.js
+++ b/test/test_data_cache.js
@@ -67,5 +67,22 @@ describe('DataCache', () => {
             assert.equal(dataCache.pm25, 6.87);
         });
 
+        const sampleDataTempBME280 = require('./../sample_data/api_data_temp_bme280.json')[0];
+
+        it('should parse temperature data from BME280 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updateTemperature(sampleDataTempBME280);
+            assert.equal(dataCache.temperature, 10.87);
+        });
+        it('should parse humidity data from BME280 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updateHumidity(sampleDataTempBME280);
+            assert.equal(dataCache.humidity, 54.34);
+        });
+        it('should parse air pressure data from BME280 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updatePressure(sampleDataTempBME280);
+            assert.equal(dataCache.pressure, 990.4013);
+        });
     });
 });

--- a/test/test_data_cache.js
+++ b/test/test_data_cache.js
@@ -33,6 +33,11 @@ describe('DataCache', () => {
             dataCache._updateHumidity(sampleDataBME280);
             assert.equal(dataCache.humidity, 86.66);
         });
+        it('should parse air pressure data from BME280 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updatePressure(sampleDataBME280);
+            assert.equal(dataCache.pressure, 1000.0354);
+        });
         it('should parse air particulate data from SDS011 correctly', () => {
             const dataCache = new DataCache();
             dataCache._updateAirQuality(sampleDataBME280);


### PR DESCRIPTION
Hi Thomas,

Thanks for your work on the Homebridge plugin for the Luftdaten sensor!

The following PR add support for reading pressure data from the BME280 sensor using a custom characteristic so that it can be displayed in the Eve app. This has no impact on the Home app, and the air pressure characteristic only shows in the Eve app when pressure data is available.

Note that the air pressure characteristic was added as an optional characteristic to the temperature sensor service. The [homebridge-bme280](https://github.com/rxseger/homebridge-bme280) plugin did something similar. Elagato devices supposedly provide a custom air pressure service (see comments near the bottom of [this page](https://gist.github.com/simont77/3f4d4330fa55b83f8ca96388d9004e7d)), but I couldn't get it to show in the Eve app.

This should hopefully fix issue #10. Let me know if you have any questions.

Here is a screenshot of the Eve app showing air pressure data:

![img_2541](https://user-images.githubusercontent.com/471977/37033141-308ce972-2145-11e8-8d9f-f54e07138ee4.png)

