### PR TITLE
Add support for other sensor types

### DIFF
--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -57,7 +57,7 @@ class DataCache {
   }
 
   _updateTemperature(json) {
-    const tempKeys = ['BME280_temperature', 'temperature'];
+    const tempKeys = ['BME280_temperature', 'BMP_temperature', 'temperature'];
     for (let key of tempKeys) {
       const value = this._findValue(json, key);
       if (value) {
@@ -68,7 +68,7 @@ class DataCache {
   }
 
   _updatePressure(json) {
-    const pressureKeys = ['BME280_pressure', 'pressure'];
+    const pressureKeys = ['BME280_pressure', 'BMP_pressure', 'pressure'];
     for (let key of pressureKeys) {
       const value = this._findValue(json, key);
       if (value) {

--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -80,8 +80,8 @@ class DataCache {
   }
 
   _updateAirQuality(json) {
-    const pm25keys = ['SDS_P2', 'P2', 'PMS_P2'];
-    const pm10keys = ['SDS_P1', 'P1', 'PMS_P1'];
+    const pm25keys = ['SDS_P2', 'P2', 'PMS_P2', 'HPM_P2'];
+    const pm10keys = ['SDS_P1', 'P1', 'PMS_P1', 'HPM_P1'];
 
     for (let key of pm25keys) {
       const value = this._findValue(json, key);

--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -46,7 +46,7 @@ class DataCache {
   }
 
   _updateHumidity(json) {
-    const humidityKeys = ['humidity', 'BME280_humidity'];
+    const humidityKeys = ['BME280_humidity', 'humidity'];
     for (let key of humidityKeys) {
       const value = this._findValue(json, key);
       if (value) {
@@ -57,7 +57,7 @@ class DataCache {
   }
 
   _updateTemperature(json) {
-    const tempKeys = ['temperature', 'BME280_temperature'];
+    const tempKeys = ['BME280_temperature', 'temperature'];
     for (let key of tempKeys) {
       const value = this._findValue(json, key);
       if (value) {
@@ -68,7 +68,7 @@ class DataCache {
   }
 
   _updatePressure(json) {
-    const pressureKeys = ['pressure', 'BME280_pressure'];
+    const pressureKeys = ['BME280_pressure', 'pressure'];
     for (let key of pressureKeys) {
       const value = this._findValue(json, key);
       if (value) {

--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -46,7 +46,7 @@ class DataCache {
   }
 
   _updateHumidity(json) {
-    const humidityKeys = ['BME280_humidity', 'humidity'];
+    const humidityKeys = ['HTU21D_humidity', 'BME280_humidity', 'humidity'];
     for (let key of humidityKeys) {
       const value = this._findValue(json, key);
       if (value) {
@@ -57,7 +57,8 @@ class DataCache {
   }
 
   _updateTemperature(json) {
-    const tempKeys = ['BME280_temperature', 'BMP_temperature', 'temperature'];
+    const tempKeys = ['DS18B20_temperature', 'HTU21D_temperature', 'BME280_temperature',
+                      'BMP_temperature', 'temperature'];
     for (let key of tempKeys) {
       const value = this._findValue(json, key);
       if (value) {
@@ -79,8 +80,8 @@ class DataCache {
   }
 
   _updateAirQuality(json) {
-    const pm25keys = ['SDS_P2', 'P2'];
-    const pm10keys = ['SDS_P1', 'P1'];
+    const pm25keys = ['SDS_P2', 'P2', 'PMS_P2'];
+    const pm10keys = ['SDS_P1', 'P1', 'PMS_P1'];
 
     for (let key of pm25keys) {
       const value = this._findValue(json, key);

--- a/sample_data/data_DHT22_BMP280.json
+++ b/sample_data/data_DHT22_BMP280.json
@@ -1,0 +1,46 @@
+{
+   "software_version" : "NRZ-2017-099",
+   "age" : "107",
+   "sensordatavalues" : [
+      {
+         "value_type" : "SDS_P1",
+         "value" : "21.15"
+      },
+      {
+         "value_type" : "SDS_P2",
+         "value" : "4.22"
+      },
+      {
+         "value_type" : "temperature",
+         "value" : "12.40"
+      },
+      {
+         "value_type" : "humidity",
+         "value" : "70.20"
+      },
+      {
+         "value_type" : "BMP_temperature",
+         "value" : "12.70"
+      },
+      {
+         "value_type" : "BMP_pressure",
+         "value" : "98360.06"
+      },
+      {
+         "value_type" : "samples",
+         "value" : "591674"
+      },
+      {
+         "value_type" : "min_micro",
+         "value" : "236"
+      },
+      {
+         "value_type" : "max_micro",
+         "value" : "1197798"
+      },
+      {
+         "value_type" : "signal",
+         "value" : "-71"
+      }
+   ]
+}

--- a/test/test_data_cache.js
+++ b/test/test_data_cache.js
@@ -44,6 +44,23 @@ describe('DataCache', () => {
             assert.equal(dataCache.pm10, 6.50);
             assert.equal(dataCache.pm25, 3.20);
         });
+
+        const sampleDataDHT22BMP280 = require('./../sample_data/data_DHT22_BMP280.json');
+        it('should parse temperature data from BMP280 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updateTemperature(sampleDataDHT22BMP280);
+            assert.equal(dataCache.temperature, 12.70);
+        });
+        it('should parse humidity data from DHT22 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updateHumidity(sampleDataDHT22BMP280);
+            assert.equal(dataCache.humidity, 70.20);
+        });
+        it('should parse air pressure data from BMP280 correctly', () => {
+            const dataCache = new DataCache();
+            dataCache._updatePressure(sampleDataDHT22BMP280);
+            assert.equal(dataCache.pressure, 983.6006);
+        });
     });
 
     describe('luftdaten.info API data', () => {


### PR DESCRIPTION
Hi Thomas,

The following pull request adds support for other sensor types supported by the Airrohr. It also prioritises the BME280 over the DHT22 when both sensors are present in local data. Deciding which sensor is more accurate is not a clear-cut issue, but I think the consensus on BME280 vs. DHT22 is pretty strong. See opendata-stuttgart/sensors-software#170 for example.

Ideally it would be nice to let the user define (in the configuration file) which sensor should take priority when a given metric is available through multiple sensors, but this might be too much work for such an uncommon use case.

I hope I'm not being anoying with all these pull requests! I promise I'm almost done. :smile: