### PR TITLE
Make public temperature optional #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,212 +20,228 @@ module.exports = function(homebridge) {
 };
 
 function AirRohrAccessory(log, config) {
-    this.category = Accessory.Categories.SENSOR;
-    this.log = log;
-    this.displayName = config["name"];
-    this.dataCache = null;
-    this.jsonURL = config["json_data"];
-    this.airQualityDataURL = config["public_airquality_json_data"];
-    this.temperatureDataURL = config["public_temperature_json_data"];
-    if (!this.jsonURL && !this.airQualityDataURL && !this.temperatureDataURL) {
-      throw new Error("Invalid configuration")
-    }
+  this.category = Accessory.Categories.SENSOR;
+  this.log = log;
+  this.displayName = config["name"];
+  this.dataCache = null;
+  this.jsonURL = config["json_data"];
+  this.airQualityDataURL = config["public_airquality_json_data"];
+  this.temperatureDataURL = config["public_temperature_json_data"];
+  if (!this.jsonURL && !this.airQualityDataURL && !this.temperatureDataURL) {
+    throw new Error("Invalid configuration")
+  }
 
-    this.sensorId = config["sensor_id"];
-    this.updateIntervalSeconds = config["update_interval_seconds"];
-    if (!this.updateIntervalSeconds) {
-      this.updateIntervalSeconds = 120;
-    }
-    this.log("AirRohr: Update interval", this.updateIntervalSeconds, "s");
+  this.sensorId = config["sensor_id"];
+  this.updateIntervalSeconds = config["update_interval_seconds"];
+  if (!this.updateIntervalSeconds) {
+    this.updateIntervalSeconds = 120;
+  }
+  this.log("AirRohr: Update interval", this.updateIntervalSeconds, "s");
 
-    this.historyOptions = config["history"] || {};
+  this.historyOptions = config["history"] || {};
 
-    // Information
+  const haveAirQualityData = !!this.jsonURL || !!this.airQualityDataURL;
+  const haveTemperatureData = !!this.jsonURL || !!this.temperatureDataURL;
 
-    this.informationService = new Service.AccessoryInformation();
-    this.informationService.setCharacteristic(
-      Characteristic.Manufacturer,
-      "luftdaten.info"
-    );
-    this.informationService.setCharacteristic(
-      Characteristic.Model,
-      "Feinstaubsensor"
-    );
-    this.informationService.setCharacteristic(
-      Characteristic.SerialNumber,
-      this.sensorId
-    );
+  // Information
 
+  this.informationService = new Service.AccessoryInformation();
+  this.informationService.setCharacteristic(
+    Characteristic.Manufacturer,
+    "luftdaten.info"
+  );
+  this.informationService.setCharacteristic(
+    Characteristic.Model,
+    "Feinstaubsensor"
+  );
+  this.informationService.setCharacteristic(
+    Characteristic.SerialNumber,
+    this.sensorId
+  );
+
+  if (haveTemperatureData) {
     // Temperature Sensor
     this.temperatureService = new Service.TemperatureSensor(`Temperature ${this.displayName}`);
     this.temperatureService.addOptionalCharacteristic(CustomCharacteristic.AirPressure);
 
     // Humidity sensor
     this.humidityService = new Service.HumiditySensor(`Humidity ${this.displayName}`);
+    this.loggingService = new FakeGatoHistoryService('weather', this, {storage: 'fs'});
+  }
 
+  if (haveAirQualityData) {
     // AirQuality Sensor
     this.airQualityService = new Service.AirQualitySensor(`Air quality ${this.displayName}`);
-    this.airQualityService.isPrimaryService = true;
-    this.airQualityService.linkedServices = [this.humidityService, this.temperatureService];
 
-    this.loggingService = new FakeGatoHistoryService('weather', this, this.historyOptions);
+    if (haveTemperatureData) {
+      this.airQualityService.isPrimaryService = true;
+      this.airQualityService.linkedServices = [this.humidityService, this.temperatureService];
+    }
+  }
 
-    this.updateServices = (dataCache) => {
-      this.dataCache = dataCache;
-      this.informationService.setCharacteristic(
-        Characteristic.FirmwareRevision,
-        dataCache.software_version
+  this.updateServices = (dataCache) => {
+    this.dataCache = dataCache;
+    this.informationService.setCharacteristic(
+      Characteristic.FirmwareRevision,
+      dataCache.software_version
+    );
+    let temp = dataCache.temperature;
+    if (haveTemperatureData && temp) {
+      this.log("Measured temperature", temp, "°C");
+      this.temperature = parseFloat(temp);
+      this.temperatureService.setCharacteristic(
+        Characteristic.CurrentTemperature,
+        this.temperature
       );
-      let temp = dataCache.temperature;
-      if (temp) {
-        this.log("Measured temperature", temp, "°C");
-        this.temperature = parseFloat(temp);
-        this.temperatureService.setCharacteristic(
-          Characteristic.CurrentTemperature,
-          this.temperature
-        );
-      }
-      let humidity = dataCache.humidity;
-      if (humidity) {
-        this.log("Measured humidity", humidity, "%");
-        this.humidity = humidity;
-        this.humidityService.setCharacteristic(
-          Characteristic.CurrentRelativeHumidity,
-          this.humidity
-        );
-      }
-      let pressure = dataCache.pressure;
-      if (pressure) {
-        this.log("Measured pressure", pressure, "hPa");
-        this.pressure = pressure;
-        this.temperatureService.setCharacteristic(
-          CustomCharacteristic.AirPressure,
-          this.pressure
-        );
-      }
-      let pm25 = dataCache.pm25;
-      if (pm25) {
-        this.log("Measured PM2.5", pm25, "µg/m³");
-        this.pm25 = pm25;
-        this.airQualityService.setCharacteristic(
-          Characteristic.PM2_5Density,
-          this.pm25
-        );
-      }
-      let pm10 = dataCache.pm10;
-      if (pm10) {
-        this.log("Measured PM10", pm10, "µg/m³");
-        this.pm10 = pm10;
-        this.airQualityService.setCharacteristic(
-          Characteristic.PM10Density,
-          this.pm10
-        );
-      }
+    }
+    let humidity = dataCache.humidity;
+    if (haveTemperatureData && humidity) {
+      this.log("Measured humidity", humidity, "%");
+      this.humidity = humidity;
+      this.humidityService.setCharacteristic(
+        Characteristic.CurrentRelativeHumidity,
+        this.humidity
+      );
+    }
+    let pressure = dataCache.pressure;
+    if (haveTemperatureData && pressure) {
+      this.log("Measured pressure", pressure, "hPa");
+      this.pressure = pressure;
+      this.temperatureService.setCharacteristic(
+        CustomCharacteristic.AirPressure,
+        this.pressure
+      );
+    }
+    let pm25 = dataCache.pm25;
+    if (haveAirQualityData && pm25) {
+      this.log("Measured PM2.5", pm25, "µg/m³");
+      this.pm25 = pm25;
+      this.airQualityService.setCharacteristic(
+        Characteristic.PM2_5Density,
+        this.pm25
+      );
+    }
+    let pm10 = dataCache.pm10;
+    if (haveAirQualityData && pm10) {
+      this.log("Measured PM10", pm10, "µg/m³");
+      this.pm10 = pm10;
+      this.airQualityService.setCharacteristic(
+        Characteristic.PM10Density,
+        this.pm10
+      );
+    }
 
-      // Calculate AirQuality:
-      //  average percentage of values below thesholds defined by WHO
-      //  <=40% -> EXCELLENT
-      //  <=60% -> GOOD
-      //  <=80% -> FAIR
-      //  <=100% -> INFERIOR
-      //  >100% -> POOR Since poor quality can be used as a trigger.
-      if (pm10 && pm25) {
-        // PM10: 50 µg/m³ daily limit
-        let percentPm10 = parseFloat(pm10) / 50.0;
-        // PM2.5: 25 µg/m³ daily limit
-        let percentPm25 = parseFloat(pm25) / 25.0;
-        let qualityPercentage = (percentPm10 + percentPm25) / 2.0;
+    // Calculate AirQuality:
+    //  average percentage of values below thesholds defined by WHO
+    //  <=40% -> EXCELLENT
+    //  <=60% -> GOOD
+    //  <=80% -> FAIR
+    //  <=100% -> INFERIOR
+    //  >100% -> POOR Since poor quality can be used as a trigger.
+    if (haveAirQualityData && pm10 && pm25) {
+      // PM10: 50 µg/m³ daily limit
+      let percentPm10 = parseFloat(pm10) / 50.0;
+      // PM2.5: 25 µg/m³ daily limit
+      let percentPm25 = parseFloat(pm25) / 25.0;
+      let qualityPercentage = (percentPm10 + percentPm25) / 2.0;
 
-        let absChange = Math.abs(this.qualityPercentage - qualityPercentage);
-        let wasNotSet = this.qualityPercentage == undefined || this.qualityPercentage == null;
-        this.qualityPercentage = qualityPercentage;
-        // Only set new quality level if there was a significant change
-        if (wasNotSet || absChange >= 0.05) {
-          if (qualityPercentage <= 0.4) {
-            this.airQuality = Characteristic.AirQuality.EXCELLENT;
-          } else if (qualityPercentage <= 0.6) {
-            this.airQuality = Characteristic.AirQuality.GOOD;
-          } else if (qualityPercentage <= 0.8) {
-            this.airQuality = Characteristic.AirQuality.FAIR;
-          } else if (qualityPercentage <= 1.0) {
-            this.airQuality = Characteristic.AirQuality.INFERIOR;
-          } else if (qualityPercentage > 1.0) {
-            this.airQuality = Characteristic.AirQuality.POOR;
-          } else {
-            this.airQuality = Characteristic.AirQuality.UNKNOWN;
-          }
-          this.airQualityService.setCharacteristic(
-            Characteristic.AirQuality,
-            this.airQuality
-          );
-        }
-      }
-
-      this.loggingService.addEntry({
-          time: moment().unix(),
-          temp: temp,
-          pressure: pressure,
-          humidity: humidity
-      });
-    };
-
-    this.dataCache = new DataCache();
-    
-    this.isUpdating = false;
-    this.updateCache = (callback) => {
-      if (this.isUpdating) {
-        if (callback) {
-          callback(null);
-        }
-        return;
-      }
-      this.isUpdating = true;
-
-      const updateCallback = (error) => {
-        this.isUpdating = false;
-        if (error) {
-          this.log(`Could not get sensor data: ${error}`);
+      let absChange = Math.abs(this.qualityPercentage - qualityPercentage);
+      let wasNotSet = this.qualityPercentage == undefined || this.qualityPercentage == null;
+      this.qualityPercentage = qualityPercentage;
+      // Only set new quality level if there was a significant change
+      if (wasNotSet || absChange >= 0.05) {
+        if (qualityPercentage <= 0.4) {
+          this.airQuality = Characteristic.AirQuality.EXCELLENT;
+        } else if (qualityPercentage <= 0.6) {
+          this.airQuality = Characteristic.AirQuality.GOOD;
+        } else if (qualityPercentage <= 0.8) {
+          this.airQuality = Characteristic.AirQuality.FAIR;
+        } else if (qualityPercentage <= 1.0) {
+          this.airQuality = Characteristic.AirQuality.INFERIOR;
+        } else if (qualityPercentage > 1.0) {
+          this.airQuality = Characteristic.AirQuality.POOR;
         } else {
-          this.updateServices(this.dataCache);
+          this.airQuality = Characteristic.AirQuality.UNKNOWN;
         }
-        if (callback) {
-          callback(error);
-        }
-      };
+        this.airQualityService.setCharacteristic(
+          Characteristic.AirQuality,
+          this.airQuality
+        );
+      }
+    }
 
-      if (this.jsonURL) {
-        this.dataCache.updateFromLocalSensor(this.jsonURL, updateCallback);
-      } else if (this.airQualityDataURL && this.temperatureDataURL) {
-        this.dataCache.updateFromLuftdatenAPI(this.airQualityDataURL, this.temperatureDataURL, updateCallback);
+    if (haveTemperatureData) {
+      this.loggingService.addEntry({
+         time: moment().unix(),
+         temp: temp,
+         pressure: pressure,
+         humidity: humidity
+      });
+    }
+  };
+
+  this.dataCache = new DataCache();
+
+  this.isUpdating = false;
+  this.updateCache = (callback) => {
+    if (this.isUpdating) {
+      if (callback) {
+        callback(null);
+      }
+      return;
+    }
+    this.isUpdating = true;
+
+    const updateCallback = (error) => {
+      this.isUpdating = false;
+      if (error) {
+        this.log(`Could not get sensor data: ${error}`);
+      } else {
+        this.updateServices(this.dataCache);
+      }
+      if (callback) {
+        callback(error);
       }
     };
 
-    let time = this.updateIntervalSeconds * 1000; // 1 minute
-    setInterval(() => {
-      this.updateCache();
-    }, time);
-    this.updateCache();
+    if (this.jsonURL) {
+      this.dataCache.updateFromLocalSensor(this.jsonURL, updateCallback);
+    } else if (this.airQualityDataURL || this.temperatureDataURL) {
+      this.dataCache.updateFromLuftdatenAPI(this.airQualityDataURL, this.temperatureDataURL, updateCallback);
+    }
+  };
 
+  let time = this.updateIntervalSeconds * 1000; // 1 minute
+  setInterval(() => {
+    this.updateCache();
+  }, time);
+  this.updateCache();
+
+
+  if (haveAirQualityData) {
     this.airQualityService
-        .getCharacteristic(Characteristic.AirQuality)
-        .on("get", (callback) => {
-            callback(null, this.airQuality);
-        });
+      .getCharacteristic(Characteristic.AirQuality)
+      .on("get", (callback) => {
+        callback(null, this.airQuality);
+      });
     this.airQualityService
-        .getCharacteristic(Characteristic.PM2_5Density)
-        .on("get", (callback) => {
-            callback(null, this.pm25);
-        });
+      .getCharacteristic(Characteristic.PM2_5Density)
+      .on("get", (callback) => {
+        callback(null, this.pm25);
+      });
     this.airQualityService
-        .getCharacteristic(Characteristic.PM10Density)
-        .on("get", (callback) => {
-            callback(null, this.pm10);
-        });
+      .getCharacteristic(Characteristic.PM10Density)
+      .on("get", (callback) => {
+        callback(null, this.pm10);
+      });
+  }
+
+  if (haveTemperatureData) {
     this.humidityService
-        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .on("get", (callback) => {
-            callback(null, this.humidity);
-        });
+      .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+      .on("get", (callback) => {
+        callback(null, this.humidity);
+      });
     this.temperatureService
       .getCharacteristic(Characteristic.CurrentTemperature)
       .setProps({
@@ -237,10 +253,19 @@ function AirRohrAccessory(log, config) {
         perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
       })
       .on("get", (callback) => {
-          callback(null, this.temperature);
+        callback(null, this.temperature);
       });
+  }
 };
 
 AirRohrAccessory.prototype.getServices = function() {
-  return [this.temperatureService, this.informationService, this.humidityService, this.airQualityService, this.loggingService];
+  return [
+    this.temperatureService,
+    this.informationService,
+    this.humidityService,
+    this.airQualityService,
+    this.loggingService
+  ].filter(function(s) {
+    return s !== undefined;
+  });
 };

--- a/index.js
+++ b/index.js
@@ -19,41 +19,6 @@ module.exports = function(homebridge) {
   );
 };
 
-function getCurrentSensorData(jsonURL, callback) {
-  http.get(jsonURL, (res) => {
-    const { statusCode } = res;
-    const contentType = res.headers['content-type'];
-
-    let error;
-    if (statusCode !== 200) {
-      error = new Error('Request Failed.\n' +
-                        `Status Code: ${statusCode}`);
-    } else if (!/^application\/json/.test(contentType)) {
-      error = new Error('Invalid content-type.\n' +
-                        `Expected application/json but received ${contentType}`);
-    }
-    if (error) {
-      res.resume();
-      callback(null, error);
-      return;
-    }
-
-    res.setEncoding('utf8');
-    let rawData = '';
-    res.on('data', (chunk) => { rawData += chunk; });
-    res.on('end', () => {
-      try {
-        const parsedData = JSON.parse(rawData);
-        callback(parsedData, null);
-      } catch (e) {
-        callback(null, e);
-      }
-    });
-  }).on('error', (e) => {
-    callback(null, e);
-  });
-};
-
 function AirRohrAccessory(log, config) {
     this.category = Accessory.Categories.SENSOR;
     this.log = log;

--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -11,24 +11,50 @@ class DataCache {
   }
 
   updateFromLuftdatenAPI(airQualityUrl, temperatureSensorUrl, callback) {
-    this._loadCurrentSensorData(airQualityUrl, (error, airquality_json) => {
-      if (error) {
-        callback(error);
-        return;
-      }
-      this._loadCurrentSensorData(temperatureSensorUrl, (error, temp_json) => {
+    let airQualityDataLoaded = !airQualityUrl;
+    let temperatureDataLoaded = !temperatureSensorUrl;
+
+    const loadAirQualityData = () => {
+      this._loadCurrentSensorData(airQualityUrl, (error, airquality_json) => {
         if (error) {
           callback(error);
           return;
         }
 
         this._updateAirQuality(airquality_json);
+
+        airQualityDataLoaded = true;
+        next();
+      });
+    };
+
+    const loadTemperatureData = () => {
+      this._loadCurrentSensorData(temperatureSensorUrl, (error, temp_json) => {
+        if (error) {
+          callback(error);
+          return;
+        }
+
         this._updateHumidity(temp_json);
         this._updateTemperature(temp_json);
         this._updatePressure(temp_json);
-        callback(null);
+
+        temperatureDataLoaded = true;
+        next();
       });
-    });
+    };
+
+    const next = () => {
+      if (!airQualityDataLoaded) {
+        loadAirQualityData();
+      } else if (!temperatureDataLoaded) {
+        loadTemperatureData();
+      } else {
+        callback(null);
+      }
+    };
+
+    next();
   }
 
   updateFromLocalSensor(url, callback) {
@@ -125,7 +151,7 @@ class DataCache {
     http.get(jsonURL, (res) => {
       const { statusCode } = res;
       const contentType = res.headers['content-type'];
-  
+
       let error;
       if (statusCode !== 200) {
         error = new Error('Request Failed.\n' +
@@ -139,7 +165,7 @@ class DataCache {
         callback(error, null);
         return;
       }
-  
+
       res.setEncoding('utf8');
       let rawData = '';
       res.on('data', (chunk) => { rawData += chunk; });


### PR DESCRIPTION
Thanks @alexryd

Copy & Paste from [PR19](https://github.com/toto/homebridge-airrohr/pull/19) with index.js conflict fix.

---

This PR makes the `public_temperature_json_data` and `public_airquality_json_data` config variables independent of each other so that it's possible to only load air quality data without temperature data or the other way around. So for instance if public_temperature_json_data is not specified in the config, no `TemperatureSensor` or `HumiditySensor` services will be exposed and no temperature data will be loaded.
Fixes [#16](https://github.com/toto/homebridge-airrohr/issues/16) and fixes [#15](https://github.com/toto/homebridge-airrohr/issues/15).