### PR TITLE
Add support for BMP280 (fixes #57)

### DIFF
--- a/lib/data_cache.js
+++ b/lib/data_cache.js
@@ -84,7 +84,7 @@ class DataCache {
 
   _updateTemperature(json) {
     const tempKeys = ['DS18B20_temperature', 'HTU21D_temperature', 'BME280_temperature',
-                      'BMP_temperature', 'SHT3X_temperature', 'temperature'];
+                      'BMP_temperature', 'BMP280_temperature', 'SHT3X_temperature', 'temperature'];
     for (let key of tempKeys) {
       const value = this._findValue(json, key);
       if (value) {
@@ -95,7 +95,7 @@ class DataCache {
   }
 
   _updatePressure(json) {
-    const pressureKeys = ['BME280_pressure', 'BMP_pressure', 'pressure'];
+    const pressureKeys = ['BME280_pressure', 'BMP_pressure', 'BMP280_pressure', 'pressure'];
     for (let key of pressureKeys) {
       const value = this._findValue(json, key);
       if (value) {


### PR DESCRIPTION
Fix for #57 adding support for BMP280.  Setting the property disable_humidity to true in the configuration will mean that the humidity sensor will not be added to the Homekit devices.